### PR TITLE
make CONT lines robust against missing parent line text

### DIFF
--- a/gedcom7/parser.py
+++ b/gedcom7/parser.py
@@ -18,7 +18,10 @@ def loads(string: str) -> List[GedcomStructure]:
         level = int(data["level"])
         # handle continuation lines
         if data["tag"] == const.CONT:
-            context[level - 1].text += "\n" + data["linestr"]
+            if not context[level - 1].text:
+                context[level - 1].text =  ""
+                
+            context[level - 1].text += "\n" + data["linestr"] if data["linestr"] else ""
             continue
         structure = GedcomStructure(
             tag=ext.get(data["tag"]) or data["tag"],


### PR DESCRIPTION
I recently got a gedcom7 file which has notes of kind

```
0 @N6534875@ SNOTE
1 CONT some text 
1 CONT some further text
0 @N87589346@ SNOTE
1 CONT other text
1 CONT
0 @N45362@ SNOTE
1 CONT text
```

this fails twice in gedcom7:
- the first CONT line in the note record does not have a previous line with any text
- one CONT line does not have content at all

While starting the content of a record with CONT lines seems not to be intended by the gedcom7 standard, empty CONT lines are explicitely allowed. 
To make the parser more robust, I propose to accept even the CONT lines as first line in a record with just impliying, that the text is empty so far - which should be a very robust assumption anyway.

